### PR TITLE
expected full read to fix anthropic bug

### DIFF
--- a/core/src/languageModels/Anthropic.ts
+++ b/core/src/languageModels/Anthropic.ts
@@ -39,10 +39,6 @@ async function* anthropicToOpenAiStream(stream: MessageStream) {
 
   const now = Date.now()
   for await (const evt of stream) {
-    // console.log('evt: ', evt)
-    if (evt.type === "message_stop") {
-      return
-    }
 
     if (evt.type === "message_start") {
       id = evt.message.id

--- a/core/tests/languageModels/anthropic.spec.ts
+++ b/core/tests/languageModels/anthropic.spec.ts
@@ -5,7 +5,7 @@ import { AnthropicProcessor } from "../../src/languageModels/Anthropic";
 // this is set to skip because it requires a locally running LLM server or API keys other than OpenAI
 describe.skip("AnthropicProcessor", () => {
   before(() => {
-    console.log('noting anthropic does not work with bogus')
+    console.log('noting anthropic does not work with Bogus')
   })
 
   const step = new CortexStep("bob", {
@@ -27,6 +27,9 @@ describe.skip("AnthropicProcessor", () => {
     console.log("str: ", streamed)
     expect((await nextStep).value).to.be.a("string")
     expect(streamed).to.equal((await nextStep).value)
+
+    // this is hear because there's an abort error, and it only happens after the stream has completed.
+    await new Promise((resolve) => setTimeout(resolve, 1000))
   })
 
   it('streams functions', async () => {


### PR DESCRIPTION
If you stop reading the stream before anthropic is ready then there is a triggered AbortController error that is uncatchable. This change lets Anthropic SDK control when this stream read ends.