### PR TITLE
add a note on the legacy docs

### DIFF
--- a/legacy-docs/docs/intro.md
+++ b/legacy-docs/docs/intro.md
@@ -8,6 +8,13 @@ title: Welcome
 
 > Cognitive Functions for AI Souls
 
+:::info
+
+The primary way to interact with this library is now through the `@opensouls/core` npm package. Documentation for the `@opensouls/core` package can be found at https://docs.souls.chat/core. The socialagi library itself will not receive updates.
+
+:::
+
+
 **SocialAGI** offers developers clean, simple, and extensible abstractions for directing the cognitive processes of large language models (LLMs), steamlining the creation of more effective and engaging AI souls.
 
 The library provides _Streamlined Context Management with `new CortexStep(...)`_. [CortexStep](/CortexStep/intro) facilitates the ordered construction of context with LLMs. It works on the principle of treating each interaction as a single step or functional transformation on working memory, offering a predictable and manageable way to guide the thought process of an LLM. This approach results in consistent, easier-to-follow interaction flows.

--- a/legacy-docs/docs/intro.md
+++ b/legacy-docs/docs/intro.md
@@ -10,7 +10,7 @@ title: Welcome
 
 :::info
 
-The primary way to interact with this library is now through the `@opensouls/core` npm package. Documentation for the `@opensouls/core` package can be found at https://docs.souls.chat/core. The socialagi library itself will not receive updates.
+`socialagi` is deprecated in favor of the the `@opensouls/core` package. The [Soul Engine](https://docs.souls.chat) is the best way to start building AI souls, and is now in alpha, [join our discord](https://discord.gg/opensouls) for access!
 
 :::
 


### PR DESCRIPTION
Did the simplest thing for now which is just to add an info call out right at the top of the homepage of the legacy docs.