### PR TITLE
new process return type OPE-324

### DIFF
--- a/packages/engine/etc/engine.api.md
+++ b/packages/engine/etc/engine.api.md
@@ -80,7 +80,7 @@ export const defaultRagBucketName: (blueprint: string) => string;
 export type Embedding = number[];
 
 // @public (undocumented)
-export type MentalProcess<ParamType = Record<number | string, any>, CortexStepType = any> = (args: MentalProcessArguments<ParamType, CortexStepType>) => Promise<CortexStepType | WorkingMemory>;
+export type MentalProcess<ParamType = Record<number | string, any>, CortexStepType = any> = (args: MentalProcessArguments<ParamType, CortexStepType>) => Promise<MentalProcessReturnTypes<CortexStepType, ParamType>>;
 
 // @public (undocumented)
 export interface MentalProcessArguments<ParamType, CortexStepType = any> {
@@ -91,6 +91,17 @@ export interface MentalProcessArguments<ParamType, CortexStepType = any> {
     // (undocumented)
     workingMemory: WorkingMemory;
 }
+
+// @public (undocumented)
+export interface MentalProcessReturnOptions<ParamType> {
+    // (undocumented)
+    executeNow?: boolean;
+    // (undocumented)
+    params?: ParamType;
+}
+
+// @public (undocumented)
+export type MentalProcessReturnTypes<CortexStepType, ParamType = any> = CortexStepType | WorkingMemory | [WorkingMemory, MentalProcess<ParamType>] | [WorkingMemory, MentalProcess<ParamType>, MentalProcessReturnOptions<ParamType>];
 
 // @public (undocumented)
 export type PerceptionProcessor = <PropType>(perceptionArgs: {

--- a/packages/engine/src/mentalProcess.ts
+++ b/packages/engine/src/mentalProcess.ts
@@ -6,8 +6,8 @@ export interface MentalProcessArguments<ParamType, CortexStepType = any> {
   workingMemory: WorkingMemory
 }
 
-export interface MentalProcessReturnOptions<PropType> {
-  params: PropType,
+export interface MentalProcessReturnOptions<ParamType> {
+  params?: ParamType,
   executeNow?: boolean
 }
 

--- a/packages/engine/src/mentalProcess.ts
+++ b/packages/engine/src/mentalProcess.ts
@@ -6,6 +6,13 @@ export interface MentalProcessArguments<ParamType, CortexStepType = any> {
   workingMemory: WorkingMemory
 }
 
+export interface MentalProcessReturnOptions<PropType> {
+  params: PropType,
+  executeNow?: boolean
+}
+
+export type MentalProcessReturnTypes<CortexStepType, ParamType = any> = CortexStepType | WorkingMemory | [WorkingMemory, MentalProcess<ParamType>] | [WorkingMemory, MentalProcess<ParamType>, MentalProcessReturnOptions<ParamType>]
+
 export type MentalProcess<ParamType = Record<number | string, any>, CortexStepType = any> = 
-  (args: MentalProcessArguments<ParamType, CortexStepType>) => Promise<CortexStepType | WorkingMemory>
+  (args: MentalProcessArguments<ParamType, CortexStepType>) => Promise<MentalProcessReturnTypes<CortexStepType, ParamType>>
   


### PR DESCRIPTION
builds off of #189 

these are the types to allow returning any of what's defined down there in the `MentalProcessReturnOptions`

Allowing you to switch to a new mental process and execute it now if you want.
