### PR TITLE
bugs found while deploying reggie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4713,7 +4713,8 @@
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",
         "@opensouls/core": "^0.1.2",
-        "@syncedstore/core": "^0.6.0"
+        "@syncedstore/core": "^0.6.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.43.0",

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@hocuspocus/provider": "=2.9.0",
     "@opensouls/core": "^0.1.2",
-    "@syncedstore/core": "^0.6.0"
+    "@syncedstore/core": "^0.6.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.0",

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -201,6 +201,8 @@ export class Soul extends EventEmitter<SoulEvents> {
       provider.configuration.websocketProvider.destroy()
     }
 
+    this.connection = undefined
+
     this.removeAllListeners()
   }
 

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -15,6 +15,8 @@ export enum Actions {
   SAYS = "says",
 }
 
+export type { InteractionRequest } from "@opensouls/core"
+
 export enum Events {
   // this one is sent by the server
   newSoulEvent = "newSoulEvent",
@@ -153,7 +155,15 @@ export class Soul extends EventEmitter<SoulEvents> {
     return this.connection.store
   }
 
+  get connected() {
+    return this.connection?.provider.isConnected
+  }
+
   async connect(): Promise<string> {
+    if (this.connection) {
+      console.warn("connect() called twice on soul")
+      return this.soulId
+    }
     if (!this.websocket) {
       this.selfCreatedWebsocket = true
       // eslint-disable-next-line unicorn/no-typeof-undefined
@@ -163,6 +173,12 @@ export class Soul extends EventEmitter<SoulEvents> {
       } else {
         this.websocket = getConnectedWebsocket(this.organizationSlug, this.local, Boolean(this.debug))
       }
+    }
+
+    // we need to do this a 2nd time because of the await above in the this.websocket block
+    if (this.connection) {
+      console.warn("connect() called twice on soul")
+      return this.soulId
     }
 
     this.connection = this.getProvider()


### PR DESCRIPTION
* If you call connect() twice on a soul it can do bad things, so protect that.
* it was missing the uuid dependency
* disconnect didn't do a *full* cleanup so connect() wouldn't work again
* for *now* just log a warn about all the listeners being removed... in the future I thing we should separate out disonnect() and destroy()