### PR TITLE
tools to pull/push org and blueprint stores OPE-292

### DIFF
--- a/packages/soul-engine-cli/src/commands/index.ts
+++ b/packages/soul-engine-cli/src/commands/index.ts
@@ -6,6 +6,7 @@ import createLogout from "./logout.js";
 import createLogin from "./login.js";
 import createRagCommand from "./rag/index.js";
 import createInstall from "./install.js";
+import createStoreCommand from "./stores/index.js";
 
 export const setupCLI = (program: Command) => {
   createApiKeyCommand(program);
@@ -14,5 +15,6 @@ export const setupCLI = (program: Command) => {
   createLogin(program);
   createLogout(program);
   createRagCommand(program);
+  createStoreCommand(program);
   createInstall(program);
 }

--- a/packages/soul-engine-cli/src/commands/stores/index.ts
+++ b/packages/soul-engine-cli/src/commands/stores/index.ts
@@ -1,11 +1,13 @@
 import { Command } from "commander";
 import createStoresPullCommand from "./pull.js";
+import createStoresPushCommand from "./push.js";
 
 
 const createStoreCommand = (program: Command) => {
   const subCommand = program.command('stores')
   createStoresPullCommand(subCommand)
-
+  createStoresPushCommand(subCommand)
+  
   return program
 }
 

--- a/packages/soul-engine-cli/src/commands/stores/index.ts
+++ b/packages/soul-engine-cli/src/commands/stores/index.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import createStoresPullCommand from "./pull.js";
+
+
+const createStoreCommand = (program: Command) => {
+  const subCommand = program.command('stores')
+  createStoresPullCommand(subCommand)
+
+  return program
+}
+
+export default createStoreCommand

--- a/packages/soul-engine-cli/src/commands/stores/pull.ts
+++ b/packages/soul-engine-cli/src/commands/stores/pull.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import { handleLogin } from "../../login.js";
+import { getConfig } from "../../config.js";
+import { StorePuller } from "../../stores/pull.js";
+import { parsedPackageJson } from "../../packageParser.js";
+
+const createStoresPullCommand = (program: Command) => {
+  program
+    .command('pull <bucketName>')
+    .description('Pull a specific bucket from the store. This can be in the format `:bucketName` for organization stores or `blueprintName/:bucketName` for blueprint stores.')
+    .option('-l, --local', 'Use the local configuration', false)
+    .action(async (bucketName, options: { local: boolean }) => {
+      const { local } = options;
+      console.log(`Pulling blueprint store '${bucketName}' from the store.`);
+
+      await handleLogin(local)
+      const globalConfig = await getConfig(local)
+
+      const organizationSlug = globalConfig.get("organization")
+      if (!organizationSlug) {
+        throw new Error("missing organization, even after login")
+      }
+
+      if (bucketName.startsWith("organization/")) {
+        const puller = new StorePuller(
+          {
+            organizationSlug,
+            apiKey: globalConfig.get("apiKey"),
+            local,
+            bucketName: bucketName.split("/")[1],
+          },
+        )
+
+        return await puller.pull()
+      }
+
+      const blueprint = parsedPackageJson().name
+
+      const puller = new StorePuller(
+        {
+          organizationSlug,
+          apiKey: globalConfig.get("apiKey"),
+          local,
+          blueprint,
+          bucketName,
+        },
+      )
+
+      await puller.pull()
+    });
+}
+
+export default createStoresPullCommand;
+

--- a/packages/soul-engine-cli/src/commands/stores/push.ts
+++ b/packages/soul-engine-cli/src/commands/stores/push.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { handleLogin } from "../../login.js";
+import { getConfig } from "../../config.js";
+import { StorePusher } from "../../stores/push.js";
+import { parsedPackageJson } from "../../packageParser.js";
+
+const createStoresPushCommand = (program: Command) => {
+  program
+    .command('push <bucketName>')
+    .description('Push a specific bucket to the store. This can be in the format `:bucketName` for organization stores or `blueprintName/:bucketName` for blueprint stores.')
+    .option('-l, --local', 'Use the local configuration', false)
+    .action(async (bucketName, options: { local: boolean }) => {
+      const { local } = options;
+      console.log(`Pushing blueprint store '${bucketName}' to the store.`);
+
+      await handleLogin(local)
+      const globalConfig = await getConfig(local)
+
+      const organizationSlug = globalConfig.get("organization")
+      if (!organizationSlug) {
+        throw new Error("missing organization, even after login")
+      }
+
+      if (bucketName.startsWith("organization/")) {
+        const pusher = new StorePusher(
+          {
+            organizationSlug,
+            apiKey: globalConfig.get("apiKey"),
+            local,
+            bucketName: bucketName.split("/")[1],
+          },
+        )
+
+        return await pusher.push()
+      }
+
+      const blueprint = parsedPackageJson().name
+
+      const pusher = new StorePusher(
+        {
+          organizationSlug,
+          apiKey: globalConfig.get("apiKey"),
+          local,
+          blueprint,
+          bucketName,
+        },
+      )
+
+      await pusher.push()
+    });
+}
+
+export default createStoresPushCommand;

--- a/packages/soul-engine-cli/src/packageParser.ts
+++ b/packages/soul-engine-cli/src/packageParser.ts
@@ -1,0 +1,11 @@
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+
+export interface PackageJsonWithName {
+  name: string
+}
+
+export const parsedPackageJson = (): PackageJsonWithName => {
+  const packageJsonPath = join(".", "package.json")
+  return JSON.parse(readFileSync(packageJsonPath, { encoding: "utf8" })) as PackageJsonWithName
+}

--- a/packages/soul-engine-cli/src/rag/rag-file-poster.ts
+++ b/packages/soul-engine-cli/src/rag/rag-file-poster.ts
@@ -5,6 +5,7 @@ import { join, relative } from "node:path";
 import { FileWatcher } from "../fileSystem/file-watcher.js";
 import { readDirRecursive } from "../fileSystem/recursive-reader.js";
 import { ALLOWED_RAG_FILE_EXTENSIONS, RagConfigfile, RagIngestionBody, defaultRagBucketName } from "@opensouls/engine";
+import { parsedPackageJson } from "../packageParser.js";
 
 interface RagPosterOpts {
   apiKey?: string
@@ -24,14 +25,6 @@ interface CreateWithDefaultConfigOpts {
   apiKey: string
 }
 
-interface PackageJsonWithName {
-  name: string
-}
-
-const parsedPackageJson = (): PackageJsonWithName => {
-  const packageJsonPath = join(".", "package.json")
-  return JSON.parse(readFileSync(packageJsonPath, { encoding: "utf8" }))
-}
 
 export class RagPoster {
   private apiKey: string
@@ -65,8 +58,7 @@ export class RagPoster {
       const ragConfig: RagConfigfile = JSON.parse(readFileSync(pathToRagConfig, { encoding: "utf8" }));
       bucketName = ragConfig.bucket;
     } else {
-      const packageJson = parsedPackageJson();
-      bucketName = defaultRagBucketName(packageJson.name);
+      bucketName = defaultRagBucketName(parsedPackageJson().name);
     }
 
     console.log("RAG bucket name:", bucketName)

--- a/packages/soul-engine-cli/src/stores/hash.ts
+++ b/packages/soul-engine-cli/src/stores/hash.ts
@@ -1,0 +1,7 @@
+import { createHash } from "node:crypto";
+
+export const hashContent = (data: string | Buffer) => {
+  const hash = createHash('sha256');
+  hash.update(data);
+  return hash.digest('hex');
+}

--- a/packages/soul-engine-cli/src/stores/pull.ts
+++ b/packages/soul-engine-cli/src/stores/pull.ts
@@ -1,0 +1,103 @@
+import fsExtra from 'fs-extra/esm';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { Manifest } from './types.js';
+import { hashContent } from './hash.js';
+
+export interface StorePullerOpts {
+  organizationSlug: string
+  local: boolean
+  apiKey: string
+  bucketName: string
+
+  blueprint?: string
+}
+
+export class StorePuller {
+  constructor(public opts: StorePullerOpts) {}
+
+  async pull() {
+    const manifest = await this.fetchManifest()
+    const files = manifest.entries
+
+    await fsExtra.mkdirp(this.fileSystemPath())
+
+    for (const file of Object.values(files)) {
+      const filePath = path.join(this.fileSystemPath(), file.key)
+      if (fsExtra.pathExistsSync(filePath)) {
+        const fileContent = Buffer.from(readFileSync(filePath, 'utf-8')).toString('base64')
+        // hash the base64 of the file contents
+        const localHash = hashContent(fileContent)
+        if (localHash === file.contentHash) {
+          console.log(`File ${file.key} is up to date`)
+          continue
+        }
+      }
+      console.log(`fetching ${file.key}`)
+      // if the file is not up to date, then fetch the file from the server and update it locally
+      const resp = await this.fetchFile(file.key)
+      const data = await resp.text()
+      writeFileSync(filePath, data)
+    }
+    // next get the contents of the directory and delete anything not in the manifest
+    const localFiles = readdirSync(this.fileSystemPath())
+    for (const localFile of localFiles) {
+      if (!files[localFile]) {
+        console.log(`deleting ${localFile} -- ${path.join(this.fileSystemPath(), localFile)}`)
+        // fsExtra.removeSync(path.join(this.fileSystemPath(), localFile))
+      }
+    }
+
+    console.log("your store is up to date from the server")
+  }
+
+  async fetchManifest() {
+    const { apiKey } = this.opts
+
+    const url = this.url()
+    const resp = await fetch(url, {
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+    })
+    if (!resp.ok) {
+      console.error("Failed to fetch manifest", this.opts.bucketName, { url: this.url(), response: resp.status, statusText: resp.statusText })
+      throw new Error("Failed to fetch manifest: " + this.opts.bucketName)
+    }
+
+    return resp.json() as Promise<Manifest>
+  }
+
+  fetchFile(key: string) {
+    const { apiKey } = this.opts
+
+    const url = this.url() + "/" + key
+    return fetch(url, {
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+      },
+    })
+  }
+
+  private fileSystemPath() {
+    if (this.opts.blueprint) {
+      return path.join('.', 'stores', this.opts.bucketName);
+    }
+    return path.join('.', 'stores', 'organization', this.opts.bucketName);
+  }
+
+  private url() {
+    const { organizationSlug, local } = this.opts
+
+    const rootUrl = local ? "http://localhost:4000/api" : "https://soul-engine-servers.fly.dev/api"
+
+    if (this.opts.blueprint) {
+      return `${rootUrl}/${organizationSlug}/stores/${this.opts.blueprint}/${this.opts.bucketName}`
+    }
+
+    return `${rootUrl}/${organizationSlug}/stores/${this.opts.bucketName}`
+  }
+
+
+}

--- a/packages/soul-engine-cli/src/stores/push.ts
+++ b/packages/soul-engine-cli/src/stores/push.ts
@@ -1,0 +1,111 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { Manifest } from './types.js';
+import { hashContent } from './hash.js';
+
+export interface StorePusherOpts {
+  organizationSlug: string
+  local: boolean
+  apiKey: string
+  bucketName: string
+
+  blueprint?: string
+}
+
+export class StorePusher {
+  constructor(public opts: StorePusherOpts) {}
+
+  async push() {
+    const manifest = await this.fetchManifest()
+    const files = manifest.entries
+
+    const localFiles = readdirSync(this.fileSystemPath())
+
+    for (const localFile of localFiles) {
+      const filePath = path.join(this.fileSystemPath(), localFile)
+      const fileContent = Buffer.from(readFileSync(filePath, 'utf-8')).toString('base64')
+      const localHash = hashContent(fileContent)
+
+      if (!files[localFile] || files[localFile].contentHash !== localHash) {
+        console.log(`pushing ${localFile}`)
+        await this.pushFile(localFile, fileContent)
+      }
+    }
+
+    // Delete files from the server not present locally
+    for (const fileKey in files) {
+      if (!localFiles.includes(fileKey)) {
+        console.log(`deleting ${fileKey} from server`)
+        await this.deleteFile(fileKey)
+      }
+    }
+
+    console.log("your store is up to date on the server")
+  }
+
+  async fetchManifest() {
+    const { apiKey } = this.opts
+
+    const url = this.url()
+    const resp = await fetch(url, {
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+    })
+    if (!resp.ok) {
+      console.error("Failed to fetch manifest", this.opts.bucketName, { url: this.url(), response: resp.status, statusText: resp.statusText })
+      throw new Error("Failed to fetch manifest: " + this.opts.bucketName)
+    }
+
+    return resp.json() as Promise<Manifest>
+  }
+
+  pushFile(key: string, content: string) {
+    const { apiKey } = this.opts
+
+    const url = this.url()
+    return fetch(url, {
+      method: 'POST',
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ 
+        key,
+        content,
+      }),
+    })
+  }
+
+  deleteFile(key: string) {
+    const { apiKey } = this.opts
+
+    const url = this.url() + "/" + key
+    return fetch(url, {
+      method: 'DELETE',
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+      },
+    })
+  }
+
+  private fileSystemPath() {
+    if (this.opts.blueprint) {
+      return path.join('.', 'stores', this.opts.bucketName);
+    }
+    return path.join('.', 'stores', 'organization', this.opts.bucketName);
+  }
+
+  private url() {
+    const { organizationSlug, local } = this.opts
+
+    const rootUrl = local ? "http://localhost:4000/api" : "https://soul-engine-servers.fly.dev/api"
+
+    if (this.opts.blueprint) {
+      return `${rootUrl}/${organizationSlug}/stores/${this.opts.blueprint}/${this.opts.bucketName}`
+    }
+
+    return `${rootUrl}/${organizationSlug}/stores/${this.opts.bucketName}`
+  }
+}

--- a/packages/soul-engine-cli/src/stores/types.ts
+++ b/packages/soul-engine-cli/src/stores/types.ts
@@ -1,0 +1,17 @@
+export interface BucketMetadata {
+  name: string,
+  organizationId: string,
+  blueprintId?: string,
+}
+
+export interface RecordEntry {
+  key: string,
+  contentHash: string, // Buffer?
+}
+
+export type BucketEntries  = Record<string, RecordEntry>
+
+export interface Manifest {
+  bucket: BucketMetadata
+  entries: BucketEntries
+}


### PR DESCRIPTION
dependent on https://github.com/opensouls/platform/pull/355

This adds commands to pull from and push to the engine's blueprint and organization stores.

As discussed in discord, this will create
`stores/:bucketName` or `stores/organization/:bucketName` in your working directory. Non-organization stores require a package.json with the blueprint name.

Commands work like:
```bash
npx soul-engine  stores pull docs
npx soul-engine stores push docs
```

or

```bash
npx soul-engine  stores pull organization/docs
npx soul-engine stores push organization/docs
```

When going through this pipeline, no chunking is done. Filenames represent the key, file content is exactly what will be embedded and stored.

This will allow for complex *local* pipelines to get your directory into shape, and then pushed up to the engine.