### PR TITLE
add at, length, and fix merging content (fixing vision) OPE-357 OPE-358

### DIFF
--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -424,6 +424,7 @@ export interface UsageNumbers {
 export class WorkingMemory extends EventEmitter {
     constructor({ soulName, memories, postCloneTransformation, processor }: WorkingMemoryInitOptions);
     asyncMap(callback: (memory: Memory, i?: number) => Promise<InputMemory>): Promise<WorkingMemory>;
+    at(index: number): Memory<Record<string, unknown>>;
     clone(replacementMemories?: InputMemory[]): WorkingMemory;
     concat(other: MemoryListOrWorkingMemory): WorkingMemory;
     // (undocumented)
@@ -440,6 +441,7 @@ export class WorkingMemory extends EventEmitter {
     get finished(): Promise<void>;
     // (undocumented)
     readonly id: string;
+    get length(): number;
     map(callback: (memory: Memory, i?: number) => InputMemory): WorkingMemory;
     // (undocumented)
     protected markPending(): void;

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -117,8 +117,43 @@ export class WorkingMemory extends EventEmitter {
     return [...this.internalMemories]
   }
 
+  /**
+   * The `length` attribute returns the number of memories currently stored in the WorkingMemory instance.
+  * 
+   * @returns The total number of memories.
+   * 
+   * @example
+   * ```
+   * const workingMemory = new WorkingMemory({ soulName: 'example' });
+   * console.log(workingMemory.length); // Outputs 0 (no memories there)
+   * ```
+   */
+  get length() {
+    return this.internalMemories.length
+  }
+
   private get internalMemories() {
     return this._memories()
+  }
+
+  /**
+   * Retrieves a memory at a specified index from the internal memories array.
+   * 
+   * @param index - The zero-based index of the memory to retrieve.
+   * @returns The memory object at the specified index, or undefined if the index is out of bounds.
+   * 
+   * @example
+   * ```
+   * const memoryAtIndex = workingMemory.at(1);
+   * if (memoryAtIndex) {
+   *   console.log(`Memory at index 1:`, memoryAtIndex);
+   * } else {
+   *   console.log(`No memory found at index 1.`);
+   * }
+   * ```
+   */
+  at(index: number) {
+    return this.internalMemories[index]
   }
 
   /**

--- a/packages/core/tests/WorkingMemory.spec.ts
+++ b/packages/core/tests/WorkingMemory.spec.ts
@@ -27,6 +27,31 @@ describe("WorkingMemory", () => {
     expect(memories3.memories[1].content).to.equal(memories2.memories[0].content)
   })
 
+  it("retrieves a memory at a specified index", () => {
+    const memories = new WorkingMemory({
+      soulName: "test",
+    }).withMonologue("Memory #1")
+      .withMonologue("Memory #2")
+
+    const memoryAtIndex0 = memories.at(0)
+    const memoryAtIndex1 = memories.at(1)
+    const memoryAtInvalidIndex = memories.at(3)
+
+    expect(memoryAtIndex0.content).to.equal("Memory #1")
+    expect(memoryAtIndex1.content).to.equal("Memory #2")
+    expect(memoryAtInvalidIndex).to.be.undefined
+  })
+
+  it("returns the correct length of memories", () => {
+    const memories = new WorkingMemory({
+      soulName: "test",
+    }).withMonologue("Memory #1")
+      .withMonologue("Memory #2")
+      .withMonologue("Memory #3")
+
+    expect(memories.length).to.equal(3)
+  })
+
   it("replaces the current memories with new ones", () => {
     const originalMemories = new WorkingMemory({
       soulName: "test",

--- a/packages/core/tests/processors/openAICompatibleProcessors.spec.ts
+++ b/packages/core/tests/processors/openAICompatibleProcessors.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { WorkingMemory } from "../../src/WorkingMemory.js";
-import { brainstorm, decision, externalDialog } from "../shared/cognitiveSteps.js";
+import { brainstorm, decision, externalDialog, instruction } from "../shared/cognitiveSteps.js";
 import { registerProcessor } from "../../src/processors/registry.js";
 import { OpenAIProcessor, OpenAIProcessorOpts } from "../../src/processors/OpenAIProcessor.js";
 import { z } from "zod";
@@ -150,8 +150,8 @@ describe("OpenAICompatibleProcessors", () => {
   })
 
   it("works with fireworks and complex json", async () => {
-    if (!process.env.TOGETHER_API_KEY) {
-      console.log("No TOGETHER_API_KEY, skipping test")
+    if (!process.env.FIREWORKS_API_KEY) {
+      console.log("No FIREWORKS_API_KEY, skipping test")
       return
     }
 
@@ -178,6 +178,43 @@ describe("OpenAICompatibleProcessors", () => {
     expect(stormed).to.be.a('Array')
 
     expect((bigObject as any).itemsOfKnowledge).to.be.a('array')
+  })
+
+  it("works with fireworks vision", async () => {
+    if (!process.env.FIREWORKS_API_KEY) {
+      console.log("No FIREWORKS_API_KEY, skipping test")
+      return
+    }
+
+    const url = "https://shop-pawness.com/wp-content/uploads/2019/12/LIVING-THE-HAPPY-LIFE.jpg"
+
+    const workingMemory = new WorkingMemory({
+      soulName: 'Jung',
+      memories: [
+        {
+          role: ChatMessageRoleEnum.User,
+          content: [
+            {
+              type: "text",
+              text: "Here is an image",
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: url,
+              },
+            }
+          ]
+        }
+      ],
+      processor: {
+        name: "fireworks",
+      }
+    });
+
+    const [,answered] = await instruction(workingMemory, "What is that image?", { model: "fireworks/firellava-13b" })
+    
+    expect(answered).to.include("dog")
   })
 
   it("works with mistral", async () => {


### PR DESCRIPTION
sorry for the mixed bag, noticed a bug and fixed it and figured I'd add these two things.

* adds workingMemory.at(idx) to return a memory at that index
* adds workingMemory.length which is an alias for workingMemory.memories.length
* fixes how we merge content in the processor, to restore working calls for models that enforce single system messages and alternating roles.