### PR TITLE
fix token usage in anthropic to use the actual data from the API

### DIFF
--- a/packages/core/src/processors/OpenAIProcessor.ts
+++ b/packages/core/src/processors/OpenAIProcessor.ts
@@ -1,7 +1,7 @@
 import OpenAI from "openai";
+import { encodeChatGenerator, encodeGenerator } from "gpt-tokenizer/model/gpt-4"
 import { RequestOptions } from "openai/core";
 import { trace, context } from "@opentelemetry/api";
-import { encodeChatGenerator, encodeGenerator } from "gpt-tokenizer/model/gpt-4"
 import { backOff } from "exponential-backoff";
 import { ChatMessage } from "gpt-tokenizer/GptEncoding";
 import { ZodError, fromZodError } from 'zod-validation-error';
@@ -26,7 +26,7 @@ const tracer = trace.getTracer(
   '0.0.1',
 );
 
-const tokenLength = (messagesOrContent: ChatMessage[] | string): number => {
+export const tokenLength = (messagesOrContent: ChatMessage[] | string): number => {
   // first count out all the images in the memories
   let tokenCount = 0
 

--- a/packages/core/tests/processors/OpenAIProcessor.spec.ts
+++ b/packages/core/tests/processors/OpenAIProcessor.spec.ts
@@ -29,6 +29,8 @@ describe('OpenAIProcessor', function() {
 
     const usage = await response.usage;
     expect(usage).to.have.property('input');
+    expect(usage.input).to.be.greaterThan(0);
+    expect(usage.output).to.be.greaterThan(0);
     expect(streamed).to.equal(completion);
   });
 


### PR DESCRIPTION
The bug we ran into was messages were combined using a new array content type which the encoder doesn't support yet. The tests didn't catch it because they only had a single user message in it and the bug only shows up when there are two user messages side by side (and no assistant between them).

This adds better tests for that, and also switches to using anthropics *actual* user info instead of an approximation from gpt4.