### PR TITLE
add previousMentalProcess to the useProcessManager hook

### DIFF
--- a/packages/engine/etc/engine.api.md
+++ b/packages/engine/etc/engine.api.md
@@ -210,6 +210,7 @@ export interface SoulHooks {
         invocationCount: number;
         setNextProcess: <PropType>(process: MentalProcess<PropType>, props?: PropType) => void;
         wait: (ms: number) => Promise<void>;
+        previousMentalProcess?: MentalProcess<any>;
     };
     // (undocumented)
     useProcessMemory: <T = null>(initialValue: T) => {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -161,8 +161,12 @@ export interface SoulHooks {
   useActions: () => DefaultActions
   useProcessManager: () => {
     invocationCount: number
+    /**
+     * @deprecated use the return from a MentalProcess instead.
+     */
     setNextProcess: <PropType>(process: MentalProcess<PropType>, props?: PropType) => void
     wait: (ms: number) => Promise<void>
+    previousMentalProcess?: MentalProcess<any>
   }
   usePerceptions: () => {
     invokingPerception: Perception | null | undefined,


### PR DESCRIPTION
adds the type for previousMentalProcess and marks setNextProcess as deprecated.