### PR TITLE
add support for using environment variables instead of file system configs - OPE-395

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,6 +11071,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/yjs": {
+      "version": "13.6.14",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.14.tgz",
+      "integrity": "sha512-D+7KcUr0j+vBCUSKXXEWfA+bG4UQBviAwP3gYBhkstkgwy5+8diOPMx0iqLIOxNo/HxaREUimZRxqHGAHCL2BQ==",
+      "dependencies": {
+        "lib0": "^0.2.86"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12090,7 +12106,8 @@
         "@hocuspocus/provider": "=2.9.0",
         "@opensouls/core": "^0.1.21",
         "@syncedstore/core": "^0.6.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "yjs": "=13.6.14"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.43.0",
@@ -12121,7 +12138,8 @@
         "glob": "^10.3.10",
         "handlebars": "^4.7.8",
         "open": "^10.1.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "yjs": "=13.6.14"
       },
       "bin": {
         "soul-engine": "bin/run.js"

--- a/packages/soul-engine-cli/package.json
+++ b/packages/soul-engine-cli/package.json
@@ -45,7 +45,8 @@
     "glob": "^10.3.10",
     "handlebars": "^4.7.8",
     "open": "^10.1.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "yjs": "=13.6.14"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.0",

--- a/packages/soul-engine-cli/src/commands/logout.ts
+++ b/packages/soul-engine-cli/src/commands/logout.ts
@@ -10,7 +10,6 @@ const createLogout = (program: Command) => {
       const globalConfig = await getConfig(local)
       globalConfig.set("apiKey", "")
       globalConfig.set("organization", "")
-      globalConfig.set("organization_id", "")
     })
 
 }

--- a/packages/soul-engine-cli/src/config.ts
+++ b/packages/soul-engine-cli/src/config.ts
@@ -4,7 +4,11 @@ export interface GlobalConfig {
   organization: string
 }
 
-class ApiConfig {
+/**
+ * This class is designed to provide a consistent API similar to the 'conf' package,
+ * but it specifically handles configuration set directly (in this case environment variables)
+ */
+class EnvironmentVariableConfig {
   constructor(private config: GlobalConfig) {}
 
   get(key: keyof GlobalConfig) {
@@ -21,14 +25,14 @@ export const getConfig = async (isLocal = false) => {
   if (process.env.SOUL_ENGINE_CONFIG) {
     console.log("login with config")
     const parsed = JSON.parse(Buffer.from(process.env.SOUL_ENGINE_CONFIG, "base64").toString("utf8"))
-    return new ApiConfig({
+    return new EnvironmentVariableConfig({
       apiKey: parsed.apiKey,
       organization: parsed.organization.slug,
     })
   }
 
   if (process.env.SOUL_ENGINE_API_KEY && process.env.SOUL_ENGINE_ORGANIZATION) {
-    return new ApiConfig({
+    return new EnvironmentVariableConfig({
       apiKey: process.env.SOUL_ENGINE_API_KEY,
       organization: process.env.SOUL_ENGINE_ORGANIZATION,
     })

--- a/packages/soul-engine-cli/src/config.ts
+++ b/packages/soul-engine-cli/src/config.ts
@@ -2,10 +2,38 @@
 export interface GlobalConfig {
   apiKey: string
   organization: string
-  organizationId: string
+}
+
+class ApiConfig {
+  constructor(private config: GlobalConfig) {}
+
+  get(key: keyof GlobalConfig) {
+    return this.config[key]
+  }
+
+  set(key: string, value: string) {
+    throw new Error('set undefined')
+  }
 }
 
 export const getConfig = async (isLocal = false) => {
+  // this is the one we expect pasted from the /auth/cli page.
+  if (process.env.SOUL_ENGINE_CONFIG) {
+    console.log("login with config")
+    const parsed = JSON.parse(Buffer.from(process.env.SOUL_ENGINE_CONFIG, "base64").toString("utf8"))
+    return new ApiConfig({
+      apiKey: parsed.apiKey,
+      organization: parsed.organization.slug,
+    })
+  }
+
+  if (process.env.SOUL_ENGINE_API_KEY && process.env.SOUL_ENGINE_ORGANIZATION) {
+    return new ApiConfig({
+      apiKey: process.env.SOUL_ENGINE_API_KEY,
+      organization: process.env.SOUL_ENGINE_ORGANIZATION,
+    })
+  }
+
   const { default: Conf} = await import("conf")
   const projectName = isLocal ? "soul-engine-cli-local" : "soul-engine-cli"
   return new Conf<GlobalConfig>({ projectName })

--- a/packages/soul-engine-cli/src/login.ts
+++ b/packages/soul-engine-cli/src/login.ts
@@ -32,5 +32,4 @@ export const handleLogin = async (local: boolean, force = false) => {
   console.log(`logged into ${pastedConfig.organization.name} as ${pastedConfig.user.email}`)
   globalConfig.set("apiKey", pastedConfig.apiKey)
   globalConfig.set("organization", pastedConfig.organization.slug)
-  globalConfig.set("organization_id", pastedConfig.organization.id)
 }

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -42,7 +42,8 @@
     "@hocuspocus/provider": "=2.9.0",
     "@opensouls/core": "^0.1.21",
     "@syncedstore/core": "^0.6.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "yjs": "=13.6.14"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.0",


### PR DESCRIPTION
* add yjs dependency
* remove unused 'organization_id'
* add support for two different types of environment variable config setting:
** SOUL_ENGINE_CONFIG (which is the token pasted from /auth/cli)
** SOUL_ENGINE_API_KEY and SOUL_ENGINE_ORGANIZATION (which are what you would expect)