### PR TITLE
v0.1.26

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11178,7 +11178,7 @@
     },
     "packages/core": {
       "name": "@opensouls/core",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.19.1",
@@ -11626,12 +11626,12 @@
     },
     "packages/engine": {
       "name": "@opensouls/engine",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "@opensouls/core": "^0.1.25",
-        "@opensouls/soul": "^0.1.25",
-        "soul-engine": "^0.1.25"
+        "@opensouls/core": "^0.1.26",
+        "@opensouls/soul": "^0.1.26",
+        "soul-engine": "^0.1.26"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.43.0",
@@ -12060,7 +12060,7 @@
     },
     "packages/pipeline": {
       "name": "@opensouls/pipeline",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "fs-extra": "^11.2.0",
@@ -12569,11 +12569,11 @@
     },
     "packages/soul": {
       "name": "@opensouls/soul",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",
-        "@opensouls/core": "^0.1.25",
+        "@opensouls/core": "^0.1.26",
         "@syncedstore/core": "^0.6.0",
         "uuid": "^9.0.1",
         "yjs": "=13.6.14"
@@ -12593,11 +12593,11 @@
     },
     "packages/soul-engine-cli": {
       "name": "soul-engine",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",
-        "@opensouls/engine": "^0.1.25",
+        "@opensouls/engine": "^0.1.26",
         "chokidar": "^3.6.0",
         "commander": "^12.0.0",
         "conf": "^12.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12593,7 +12593,7 @@
     },
     "packages/soul-engine-cli": {
       "name": "soul-engine",
-      "version": "0.1.26",
+      "version": "0.1.25",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12593,7 +12593,7 @@
     },
     "packages/soul-engine-cli": {
       "name": "soul-engine",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensouls/core",
   "private": false,
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "description": "The core functionality of the OPEN SOULS soul-engine",
   "main": "dist/index.mjs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/engine",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "description": "Write your own souls to run on the OPEN SOULS soul-engine",
   "main": "dist/index.mjs",
@@ -30,9 +30,9 @@
     "url": "git+https://github.com/opensouls/soul-engine.git"
   },
   "dependencies": {
-    "@opensouls/core": "^0.1.25",
-    "@opensouls/soul": "^0.1.25",
-    "soul-engine": "^0.1.25"
+    "@opensouls/core": "^0.1.26",
+    "@opensouls/soul": "^0.1.26",
+    "soul-engine": "^0.1.26"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/pipeline",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "description": "Publish and sync data from the OPEN SOULS Soul Engine.",
   "main": "dist/index.mjs",

--- a/packages/soul-engine-cli/package.json
+++ b/packages/soul-engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-engine",
-  "version": "0.1.26",
+  "version": "0.1.25",
   "bin": {
     "soul-engine": "./bin/run.js"
   },

--- a/packages/soul-engine-cli/package.json
+++ b/packages/soul-engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-engine",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "bin": {
     "soul-engine": "./bin/run.js"
   },

--- a/packages/soul-engine-cli/package.json
+++ b/packages/soul-engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-engine",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "bin": {
     "soul-engine": "./bin/run.js"
   },
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@hocuspocus/provider": "=2.9.0",
-    "@opensouls/engine": "^0.1.25",
+    "@opensouls/engine": "^0.1.26",
     "chokidar": "^3.6.0",
     "commander": "^12.0.0",
     "conf": "^12.0.0",

--- a/packages/soul-engine-cli/src/rag/rag-file-poster.ts
+++ b/packages/soul-engine-cli/src/rag/rag-file-poster.ts
@@ -65,7 +65,7 @@ export class RagPoster {
 
     const url = local ?
       `http://localhost:4000/api/${organization}/rag-ingest/${bucketName}` :
-      `https://soul-engine-servers.fly.dev/api/${organization}/rag-ingest/${bucketName}`
+      `https://servers.souls.chat/api/${organization}/rag-ingest/${bucketName}`
 
     return new RagPoster({
       apiKey,

--- a/packages/soul-engine-cli/src/sockets/soul-engine-socket.ts
+++ b/packages/soul-engine-cli/src/sockets/soul-engine-socket.ts
@@ -5,7 +5,7 @@ export const websocketUrl = (organizationSlug: string, local: boolean, debug: bo
 
   return local ?
     `ws://127.0.0.1:4000/${organizationSlug}/${urlpath}` :
-    `wss://soul-engine-servers.fly.dev/${organizationSlug}/${urlpath}`
+    `wss://servers.souls.chat/${organizationSlug}/${urlpath}`
 }
 
 export const getConnectedWebsocket = (

--- a/packages/soul-engine-cli/src/stores/pull.ts
+++ b/packages/soul-engine-cli/src/stores/pull.ts
@@ -90,7 +90,7 @@ export class StorePuller {
   private url() {
     const { organizationSlug, local } = this.opts
 
-    const rootUrl = local ? "http://localhost:4000/api" : "https://soul-engine-servers.fly.dev/api"
+    const rootUrl = local ? "http://localhost:4000/api" : "https://servers.souls.chat/api"
 
     if (this.opts.blueprint) {
       return `${rootUrl}/${organizationSlug}/stores/${this.opts.blueprint}/${this.opts.bucketName}`

--- a/packages/soul-engine-cli/src/stores/push.ts
+++ b/packages/soul-engine-cli/src/stores/push.ts
@@ -100,7 +100,7 @@ export class StorePusher {
   private url() {
     const { organizationSlug, local } = this.opts
 
-    const rootUrl = local ? "http://localhost:4000/api" : "https://soul-engine-servers.fly.dev/api"
+    const rootUrl = local ? "http://localhost:4000/api" : "https://servers.souls.chat/api"
 
     if (this.opts.blueprint) {
       return `${rootUrl}/${organizationSlug}/stores/${this.opts.blueprint}/${this.opts.bucketName}`

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/soul",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "description": "The client code for interacting with a soul on the OPEN SOULS soul engine.",
   "main": "dist/index.mjs",
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/opensouls/soul-engine#readme",
   "dependencies": {
     "@hocuspocus/provider": "=2.9.0",
-    "@opensouls/core": "^0.1.25",
+    "@opensouls/core": "^0.1.26",
     "@syncedstore/core": "^0.6.0",
     "uuid": "^9.0.1",
     "yjs": "=13.6.14"

--- a/packages/soul/src/sockets/soul-engine-socket.ts
+++ b/packages/soul/src/sockets/soul-engine-socket.ts
@@ -5,7 +5,7 @@ export const websocketUrl = (organizationSlug: string, local: boolean, debug: bo
 
   return local ?
     `ws://127.0.0.1:4000/${organizationSlug}/${urlpath}` :
-    `wss://soul-engine-servers.fly.dev/${organizationSlug}/${urlpath}`
+    `wss://servers.souls.chat/${organizationSlug}/${urlpath}`
 }
 
 export const getConnectedWebsocket = (


### PR DESCRIPTION
- Update URL for servers from previous value to `servers.souls.chat`

## Demo
This demo was recorded using a locally `npm link`ed copy of `soul-engine-cli`.

https://github.com/opensouls/soul-engine/assets/19847545/c7d6abcf-beec-445d-881a-082053f8a963

