### PR TITLE
fix once handling, add a --noopen flag to not launch the debug chat

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11487,7 +11487,7 @@
     },
     "packages/core": {
       "name": "@opensouls/core",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.19.1",
@@ -11935,12 +11935,12 @@
     },
     "packages/engine": {
       "name": "@opensouls/engine",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "@opensouls/core": "^0.1.29",
-        "@opensouls/soul": "^0.1.29",
-        "soul-engine": "^0.1.29"
+        "@opensouls/core": "^0.1.30",
+        "@opensouls/soul": "^0.1.30",
+        "soul-engine": "^0.1.30"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.43.0",
@@ -12369,7 +12369,7 @@
     },
     "packages/pipeline": {
       "name": "@opensouls/pipeline",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "fs-extra": "^11.2.0",
@@ -12878,11 +12878,11 @@
     },
     "packages/soul": {
       "name": "@opensouls/soul",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",
-        "@opensouls/core": "^0.1.29",
+        "@opensouls/core": "^0.1.30",
         "@syncedstore/core": "^0.6.0",
         "uuid": "^9.0.1",
         "yjs": "=13.6.14"
@@ -12902,11 +12902,11 @@
     },
     "packages/soul-engine-cli": {
       "name": "soul-engine",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@hocuspocus/provider": "=2.9.0",
-        "@opensouls/engine": "^0.1.29",
+        "@opensouls/engine": "^0.1.30",
         "chokidar": "^3.6.0",
         "cli-table3": "^0.6.5",
         "commander": "^12.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensouls/core",
   "private": false,
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "description": "The core functionality of the OPEN SOULS soul-engine",
   "main": "dist/index.mjs",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/engine",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "description": "Write your own souls to run on the OPEN SOULS soul-engine",
   "main": "dist/index.mjs",
@@ -30,9 +30,9 @@
     "url": "git+https://github.com/opensouls/soul-engine.git"
   },
   "dependencies": {
-    "@opensouls/core": "^0.1.29",
-    "@opensouls/soul": "^0.1.29",
-    "soul-engine": "^0.1.29"
+    "@opensouls/core": "^0.1.30",
+    "@opensouls/soul": "^0.1.30",
+    "soul-engine": "^0.1.30"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.43.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/pipeline",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "description": "Publish and sync data from the OPEN SOULS Soul Engine.",
   "main": "dist/index.mjs",

--- a/packages/soul-engine-cli/package.json
+++ b/packages/soul-engine-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soul-engine",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "bin": {
     "soul-engine": "./bin/run.js"
   },
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@hocuspocus/provider": "=2.9.0",
-    "@opensouls/engine": "^0.1.29",
+    "@opensouls/engine": "^0.1.30",
     "chokidar": "^3.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^12.0.0",

--- a/packages/soul/package.json
+++ b/packages/soul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensouls/soul",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "type": "module",
   "description": "The client code for interacting with a soul on the OPEN SOULS soul engine.",
   "main": "dist/index.mjs",
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/opensouls/soul-engine#readme",
   "dependencies": {
     "@hocuspocus/provider": "=2.9.0",
-    "@opensouls/core": "^0.1.29",
+    "@opensouls/core": "^0.1.30",
     "@syncedstore/core": "^0.6.0",
     "uuid": "^9.0.1",
     "yjs": "=13.6.14"


### PR DESCRIPTION
this is useful for apps that have side cars and we don't want the debug chat to open. Also fixes a bug with a race condition in the --once flag.