### PR TITLE
model config ope-503

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable arrow-body-style */
 import { InternalPerception, WorkingMemory } from '@opensouls/core';
-import { DeveloperInteractionRequest, Json, Perception, SoulEnvironment } from '@opensouls/core';
+import { DeveloperInteractionRequest, Json, Perception } from '@opensouls/core';
 import { MentalProcess } from './mentalProcess.js'
 
 export * from "./mentalProcess.js"
@@ -98,19 +98,6 @@ export type PerceptionProcessor = <PropType>(perceptionArgs: {
   currentProcess: MentalProcess<any>,
   workingMemory: WorkingMemory,
 }) => Promise<PerceptionProcessorReturnTypes<PropType>>
-
-export interface Blueprint {
-  name: string
-  entity: string
-  context: string
-  initialProcess: MentalProcess<any>
-  mentalProcesses: MentalProcess<any>[]
-  subprocesses?: MentalProcess<any>[]
-
-  perceptionProcessor?: PerceptionProcessor
-
-  defaultEnvironment?: SoulEnvironment
-}
 
 export interface RagConfigfile {
   bucket: string

--- a/packages/soul-engine-cli/template/package.json
+++ b/packages/soul-engine-cli/template/package.json
@@ -15,6 +15,9 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@opensouls/engine": ">=0.1.15"
+    "@opensouls/engine": ">=0.1.30"
+  },
+  "soulEngine": {
+    "defaultModel": "fast"
   }
 }


### PR DESCRIPTION
This removes the blueprint type from the public repos as there's no client side code that needs that anymore. Also adds a default "fast" model to the template making editing the default model easier.