### PR TITLE
feat: Replace`_kind` in `DeveloperDispatchedPerception` [OPE-555]

### DIFF
--- a/packages/core/src/sharedTypes/eventLog.ts
+++ b/packages/core/src/sharedTypes/eventLog.ts
@@ -45,7 +45,9 @@ export interface InternalPerception extends PerceptionBase {
 
 export type Perception = ExternalPerception | InternalPerception
 
-export type DeveloperDispatchedPerception = Omit<ExternalPerception, "_id" | "_timestamp">
+export type DeveloperDispatchedPerception = Omit<ExternalPerception, "_id" | "_kind" | "_timestamp"> & {
+  _kind?: string | SoulEventKinds.Perception
+}
 
 export interface InteractionRequest extends SoulEvent {
   _kind: SoulEventKinds.InteractionRequest

--- a/packages/core/src/sharedTypes/eventLog.ts
+++ b/packages/core/src/sharedTypes/eventLog.ts
@@ -45,7 +45,7 @@ export interface InternalPerception extends PerceptionBase {
 
 export type Perception = ExternalPerception | InternalPerception
 
-export type DeveloperDispatchedPerception = Omit<ExternalPerception, "_id" | "_kind" | "_timestamp">
+export type DeveloperDispatchedPerception = Omit<ExternalPerception, "_id" | "_timestamp">
 
 export interface InteractionRequest extends SoulEvent {
   _kind: SoulEventKinds.InteractionRequest


### PR DESCRIPTION
Reintroduce `_kind` with the appropriate type so that our published API matches current implementation.