### PR TITLE
overload fetch so that includeMetadata returns the correct types OPE-527

### DIFF
--- a/packages/engine/etc/engine.api.md
+++ b/packages/engine/etc/engine.api.md
@@ -235,9 +235,9 @@ export const useTool: <ParamType = Json, ResponseType = Json>(toolName: string) 
 export type VectorMetadata = Record<string, Json>;
 
 // @public (undocumented)
-export interface VectorRecord {
+export interface VectorRecord<T = Json> {
     // (undocumented)
-    content: Json;
+    content: T;
     // (undocumented)
     embedding?: Embedding;
     // (undocumented)
@@ -264,9 +264,14 @@ export interface VectorStoreHook {
     // (undocumented)
     delete: (key: string) => void;
     // (undocumented)
-    fetch: <T = unknown>(key: string, opts?: SoulStoreGetOpts) => Promise<(typeof opts extends {
-        includeMetadata: true;
-    } ? VectorRecord : T) | undefined>;
+    fetch: {
+        <T = Json>(key: string, opts: SoulStoreGetOpts & {
+            includeMetadata: true;
+        }): Promise<VectorRecord<T> | undefined>;
+        <T = unknown>(key: string, opts?: Exclude<SoulStoreGetOpts, {
+            includeMetadata: true;
+        }>): Promise<T | undefined>;
+    };
     // (undocumented)
     search: (query: Embedding | string, opts?: VectorStorSearchOpts) => Promise<VectorRecordWithDistance[]>;
     // (undocumented)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -49,7 +49,7 @@ export interface DefaultActions {
     */
   expire: () => void
   log: (...args: any) => void
-  speak: (message: AsyncIterable<string>|string) => void
+  speak: (message: AsyncIterable<string> | string) => void
   /**
    * Schedules a CognitiveEvent to dispatch in the future,
    * returns an eventId that can be used to cancel the scheduled event.
@@ -62,9 +62,9 @@ export interface DefaultActions {
 
 export type VectorMetadata = Record<string, Json>
 
-export interface VectorRecord {
+export interface VectorRecord<T = Json> {
   key: string
-  content: Json
+  content: T
   metadata: VectorMetadata
   embedding?: Embedding
 }
@@ -135,7 +135,10 @@ export interface VectorStorSearchOpts {
 export interface VectorStoreHook {
   createEmbedding: (content: string, model?: string) => Promise<Embedding>
   delete: (key: string) => void
-  fetch: <T = unknown>(key: string, opts?: SoulStoreGetOpts) => Promise<(typeof opts extends { includeMetadata: true } ? VectorRecord : T) | undefined>
+  fetch: {
+    <T = Json>(key: string, opts: SoulStoreGetOpts & { includeMetadata: true }): Promise<VectorRecord<T> | undefined>
+    <T = unknown>(key: string, opts?: Exclude<SoulStoreGetOpts, { includeMetadata: true }>): Promise<T | undefined>
+  }
   search: (query: Embedding | string, opts?: VectorStorSearchOpts) => Promise<VectorRecordWithDistance[]>
   set: (key: string, value: Json, metadata?: VectorMetadata, model?: string) => void
 }


### PR DESCRIPTION
the problem was that instead of overloading, was trying to do some value based typing which doesn't work - so instead overload the fetch method to look for includeMetadata and change the return type.