### PR TITLE
make sure to polyfill for all versions of node OPE-494

### DIFF
--- a/packages/soul/scripts/manualTest.ts
+++ b/packages/soul/scripts/manualTest.ts
@@ -1,0 +1,19 @@
+import "dotenv/config";
+import { Soul } from "../src/soul.js";
+
+
+const soul = new Soul({
+  blueprint: "integrator-test-soul",
+  soulId: "manual-tester",
+  organization: process.env.SOUL_ENGINE_LOCAL_ORGANIZATION!,
+  token: process.env.SOUL_ENGINE_LOCAL_API_KEY!,
+  debug: true,
+  local: true,
+})
+
+soul.on('says', async (event) => {
+  console.log('says', await event.content())
+})
+
+await soul.connect()
+

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -77,6 +77,8 @@ export type ActionEvent = {
   interactionRequest: InteractionRequest
 }
 
+
+
 export type SoulEvents = {
   [K in Actions]: (evt: ActionEvent) => void
 } & {
@@ -86,6 +88,12 @@ export type SoulEvents = {
   newPerception: (evt: InteractionRequest) => void,
   newInteractionRequest: (evt: InteractionRequest) => void,
   newSoulEvent: (evt: SoulEvent) => void,
+}
+
+// polyfill the websocket for all versions of node, but not
+// bun or the browser
+function shouldPolyfillWebsocket() {
+  return typeof process !== "undefined" && !process.versions.bun
 }
 
 // eslint-disable-next-line unicorn/prefer-event-target
@@ -173,7 +181,7 @@ export class Soul extends EventEmitter<SoulEvents> {
     if (!this.websocket) {
       this.selfCreatedWebsocket = true
       // eslint-disable-next-line unicorn/no-typeof-undefined
-      if (typeof (globalThis.WebSocket) === "undefined") {
+      if (shouldPolyfillWebsocket()) {
         const { default: ws } = await import("ws");
         this.websocket = getConnectedWebsocket(this.organizationSlug, this.local, Boolean(this.debug), { WebSocketPolyfill: ws })
       } else {


### PR DESCRIPTION
node 22 introduced a new native WebSocket and it's experimental, and apparently broken.

This change will polyfill websocket with ws even if in node 22, but not bun or browser.