### PR TITLE
feat: Add Type Safety to Cognitive Steps and Processors [OPE-580]

### DIFF
--- a/packages/core/src/processors/Processor.ts
+++ b/packages/core/src/processors/Processor.ts
@@ -1,9 +1,10 @@
 import { ZodSchema } from "zod"
 import { WorkingMemory } from "../WorkingMemory.js"
 import { ChatMessageContent, ChatMessageRoleEnum, ContentText } from "../Memory.js"
+import { SupportedModel } from "../sharedTypes/supportedModels.js"
 
 export interface UsageNumbers {
-  model: string,
+  model: SupportedModel,
   input: number,
   output: number
 }
@@ -18,7 +19,7 @@ export interface ProcessResponse<SchemaType = string> {
 export type Headers = Record<string, string | null | undefined>;
 
 export interface RequestOptions {
-  model?: string
+  model?: SupportedModel
   temperature?: number
   maxTokens?: number
 

--- a/packages/core/src/sharedTypes/supportedModels.ts
+++ b/packages/core/src/sharedTypes/supportedModels.ts
@@ -2,4 +2,9 @@ export const SUPPORTED_MODELS = ["fast", "quality", "vision", "gpt-4-turbo", "gp
 "exp/Nous-Hermes-2-Mixtral-8x7B-SFT", "exp/Nous-Hermes-2-Mixtral-8x7B-DPO", "exp/claude-3-opus", "exp/claude-3-sonnet",
 "exp/claude-3-haiku", "exp/nous-hermes-2-mixtral-fp8", "exp/hermes-2-pro-mistral-7b", "exp/firefunction-v1", "exp/firellava-13b",
 "exp/mixtral-8x22b-instruct", "exp/llama-v3-70b-instruct"];
-export type SupportedModel = typeof SUPPORTED_MODELS[number];
+
+type OrganizationSlug = string;
+type CustomModelName = string;
+export type CUSTOM_MODEL = `${OrganizationSlug}/${CustomModelName}`;
+
+export type SupportedModel = typeof SUPPORTED_MODELS[number] | CUSTOM_MODEL;

--- a/packages/core/src/sharedTypes/supportedModels.ts
+++ b/packages/core/src/sharedTypes/supportedModels.ts
@@ -1,0 +1,5 @@
+export const SUPPORTED_MODELS = ["fast", "quality", "vision", "gpt-4-turbo", "gpt-4o", "exp/OpenHermes-2p5-Mistral-7B", 
+"exp/Nous-Hermes-2-Mixtral-8x7B-SFT", "exp/Nous-Hermes-2-Mixtral-8x7B-DPO", "exp/claude-3-opus", "exp/claude-3-sonnet",
+"exp/claude-3-haiku", "exp/nous-hermes-2-mixtral-fp8", "exp/hermes-2-pro-mistral-7b", "exp/firefunction-v1", "exp/firellava-13b",
+"exp/mixtral-8x22b-instruct", "exp/llama-v3-70b-instruct"];
+export type SupportedModel = typeof SUPPORTED_MODELS[number];

--- a/packages/core/src/sharedTypes/supportedModels.ts
+++ b/packages/core/src/sharedTypes/supportedModels.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_MODELS = ["fast", "quality", "vision", "gpt-4-turbo", "gpt-4o", "exp/OpenHermes-2p5-Mistral-7B", 
+export const SUPPORTED_MODELS = ["fast", "quality", "vision", "gpt-3.5-turbo-0125", "gpt-4-0125-preview", "gpt-4-vision-preview", "gpt-4-turbo", "gpt-4o", "exp/OpenHermes-2p5-Mistral-7B", 
 "exp/Nous-Hermes-2-Mixtral-8x7B-SFT", "exp/Nous-Hermes-2-Mixtral-8x7B-DPO", "exp/claude-3-opus", "exp/claude-3-sonnet",
 "exp/claude-3-haiku", "exp/nous-hermes-2-mixtral-fp8", "exp/hermes-2-pro-mistral-7b", "exp/firefunction-v1", "exp/firellava-13b",
 "exp/mixtral-8x22b-instruct", "exp/llama-v3-70b-instruct"];


### PR DESCRIPTION
- [x] Hoist type
- [x] Add type safety to `Processor`
- [x] Add type safety to `CogitiveStep`

## QUESTIONS

- [x] ~Should we also hoist the `MODEL_MAP` here so that both can be seen and/or edited in the same place? This would also let us import it for use in other places (like our docs)~