### PR TITLE
publish to npm on release

### DIFF
--- a/.github/npm-publish.yaml
+++ b/.github/npm-publish.yaml
@@ -1,0 +1,16 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm run publish:all
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_CONFIG_TOKEN }}


### PR DESCRIPTION
these always need a little finageling but the idea is that you can run `npm run bump` which will create a release, and then this action should take over.