### PR TITLE
regional ordering fixes OPE-614

### DIFF
--- a/packages/core/.mocharc.json
+++ b/packages/core/.mocharc.json
@@ -4,6 +4,6 @@
   "timeout": 120000,
   "node-option": [
 		"experimental-specifier-resolution=node",
-		"loader=tsx"
+		"import=tsx"
 	]
 }

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -8,6 +8,8 @@ import type { MemoryTransformationOptions, PostProcessReturn, TransformOptions, 
 import { indentNicely } from "./utils.js"
 import { ChatMessageRoleEnum, InputMemory, Memory } from "./Memory.js"
 
+const DEFAULT_REGION = "default"
+
 /**
  * This file defines the structure and operations on working memory within the OPEN SOULS soul-engine.
  * Additionally, it provides interfaces for processor specifications and the handling of memory transformations and cognitive steps.
@@ -24,6 +26,7 @@ export interface WorkingMemoryInitOptions {
   soulName: string
   memories?: InputMemory[]
   processor?: ProcessorSpecification
+  regionOrder?: string[]
   /*
    *  postCloneTransformation is a hook for library developers who want to shape a working memory or provide hooks or defaults on every return of a new working memory. 
    */
@@ -77,6 +80,8 @@ export class WorkingMemory extends EventEmitter {
   private _usage: ReturnType<typeof usageFactory>
   private _postCloneTransformation: (workingMemory: WorkingMemory) => WorkingMemory
 
+  protected regionOrder?: string[]
+
   private _pending: ReturnType<typeof pendingFactory>
 
   soulName: string
@@ -84,7 +89,7 @@ export class WorkingMemory extends EventEmitter {
     name: "openai",
   })
 
-  constructor({ soulName, memories, postCloneTransformation, processor }: WorkingMemoryInitOptions) {
+  constructor({ soulName, memories, postCloneTransformation, processor, regionOrder }: WorkingMemoryInitOptions) {
     super()
     this.id = nanoid()
     this._memories = memoryFactory(this.memoriesFromInputMemories(memories || []))
@@ -92,6 +97,9 @@ export class WorkingMemory extends EventEmitter {
     if (processor) {
       this.processor = processor
     }
+
+    this.regionOrder = regionOrder
+
     this._pending = pendingFactory()
     this._postCloneTransformation = postCloneTransformation || ((workingMemory) => workingMemory)
     this._usage = usageFactory()
@@ -218,8 +226,45 @@ export class WorkingMemory extends EventEmitter {
       memories: replacementMemories || this.memories,
       postCloneTransformation: this._postCloneTransformation,
       processor: this.processor,
+      regionOrder: this.regionOrder,
     })
     return this._postCloneTransformation(newMemory)
+  }
+
+  /**
+   * Returns a new WorkingMemory with a persistent configuration for the order of regions when they are added to the WorkingMemory instance.
+   * 
+   * @param regionOrder - A list of region names in the order they should appear in the WorkingMemory.
+   * @returns A new WorkingMemory instance with the specified regional order.
+   * 
+   * @example
+   * ```
+   * const memories = new WorkingMemory({
+   *   soulName: "test",
+   * }).withMonologue("Memory #1")
+   *   .withMonologue("Memory #2")
+   *   .withRegionalOrder('system', 'summary');
+   * 
+   * // add the summary first which will go to the top of the working memory (because no system region yet)
+   * const withSummary = memories.withRegion("summary", {
+   *   role: ChatMessageRoleEnum.System,
+   *   content: 'Summary',
+   * });
+   * 
+   * // but then when we add the system, it will go to the top because of the configuration
+   * const withSystem = withSummary.withRegion("system", {
+   *   role: ChatMessageRoleEnum.System,
+   *   content: 'System',
+   * });
+   * 
+   * expect(withSystem.at(0)).to.have.property('region', 'system');
+   * expect(withSystem.at(1)).to.have.property('region', 'summary');
+   * ```
+   */
+  withRegionalOrder(...regionOrder: string[]) {
+    const clone = this.clone()
+    clone.regionOrder = regionOrder
+    return clone
   }
 
   /**
@@ -340,6 +385,10 @@ export class WorkingMemory extends EventEmitter {
    * ```
    */
   withMemory(memory: InputMemory) {
+    if (memory.region) {
+      const existingRegionalMemories = this.regionalMemories(memory.region)
+      return this.withRegion(memory.region, ...existingRegionalMemories, memory)
+    }
     return this.concat(this.normalizeMemoryListOrWorkingMemory([memory]))
   }
 
@@ -359,6 +408,9 @@ export class WorkingMemory extends EventEmitter {
    * ```
    */
   withRegion(regionName: string, ...memories: InputMemory[]) {
+    if (regionName === DEFAULT_REGION) {
+      throw new Error('default is a reserved region name for memories without a region')
+    }
     const memoriesWithRegion = this.normalizeMemoryListOrWorkingMemory(memories.map((memory) => {
       return {
         ...memory,
@@ -366,20 +418,29 @@ export class WorkingMemory extends EventEmitter {
       }
     }))
     // first we'll find where this region should go
-    const startIndex = this.regionalIndex(regionName)
+    let startIndex = this.regionalIndex(regionName)
     if (startIndex === -1) {
-      return this.prepend(memoriesWithRegion)
+      // if there is no region with that name, then it goes right before the first memory with no region
+      const firstMemoryWithoutRegion = this.memories.findIndex((memory) => {
+        return !memory.region || memory.region === DEFAULT_REGION
+      })
+      startIndex = firstMemoryWithoutRegion === -1 ? this.length : firstMemoryWithoutRegion
     }
 
     const withoutRegion = this.withoutRegions(regionName)
 
-    return this.clone(
+    const clone = this.clone(
       this.internalMemories
         .slice(0, startIndex)
         .concat(memoriesWithRegion.memories)
         .concat(withoutRegion.slice(startIndex).memories)
     )
-    // otherwise we splice it
+
+    if (this.regionOrder) {
+      return clone.orderRegions(...this.regionOrder)
+    }
+
+    return clone
   }
 
   /**
@@ -390,7 +451,7 @@ export class WorkingMemory extends EventEmitter {
    * 
    * @example
    * ```
-   * const newWorkingMemory = workingMemory.orderRegions("system", "default");
+   * const newWorkingMemory = workingMemory.orderRegions("system", DEFAULT_REGION);
    * ```
    */
   orderRegions(...regionOrder: string[]) {
@@ -399,7 +460,7 @@ export class WorkingMemory extends EventEmitter {
     const remainingMemories: Memory[] = [];
 
     this.internalMemories.forEach(memory => {
-      const region = memory.region || "default";
+      const region = memory.region || DEFAULT_REGION;
       if (regionOrder.includes(region)) {
         if (!memoriesByRegion[region]) {
           memoriesByRegion[region] = [];
@@ -436,13 +497,19 @@ export class WorkingMemory extends EventEmitter {
    */
   withoutRegions(...regionNames: string[]) {
     return this.filter((memory) => {
-      const region = memory.region || "default"
+      const region = memory.region || DEFAULT_REGION
       return !regionNames.includes(region)
     })
   }
 
   private regionalIndex(regionName: string) {
     return this.memories.findIndex((memory) => {
+      return memory.region === regionName
+    })
+  }
+  
+  private regionalMemories(regionName: string) {
+    return this.internalMemories.filter((memory) => {
       return memory.region === regionName
     })
   }

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -232,7 +232,7 @@ export class WorkingMemory extends EventEmitter {
   }
 
   /**
-   * Returns a new WorkingMemory with a persistent configuration for the order of regions when they are added to the WorkingMemory instance.
+   * Returns a new WorkingMemory with a persistent configuration for the order of regions when they are added to the WorkingMemory instance. Un-regioned memories can be referenced explicitly via the 'default' region. Otherwise, they're sorted to the end of the workingMemory.
    * 
    * @param regionOrder - A list of region names in the order they should appear in the WorkingMemory.
    * @returns A new WorkingMemory instance with the specified regional order.

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -393,8 +393,12 @@ export class WorkingMemory extends EventEmitter {
   }
 
   /**
-   * Set (add or replace) a region in the memory with the provided new memories. If the region does not exist, it will be created and added to the top of the memories.
-   * This function (like other WorkingMemory functions) is immutable and returns a new WorkingMemory instance with the updated Memory[].
+   * Set (add or replace) a region in the memory with the provided new memories. If the region does not exist,
+   * it will be created and added according to the configuration defined by #withRegionalOrder or (by default)
+   * added right after all other defined regions (right above the default region).
+   * 
+   * This function (like other WorkingMemory functions) is immutable and returns a new WorkingMemory 
+   * instance with the updated Memory[].
    * 
    * @param regionName - The name of the region where the memories will be set.
    * @param memories - The memories to add to the specified region in the WorkingMemory.

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -223,7 +223,7 @@ export class WorkingMemory extends EventEmitter {
   clone(replacementMemories?: InputMemory[]) {
     const newMemory = new WorkingMemory({
       soulName: this.soulName,
-      memories: replacementMemories || this.memories,
+      memories: replacementMemories || this.internalMemories,
       postCloneTransformation: this._postCloneTransformation,
       processor: this.processor,
       regionOrder: this.regionOrder,
@@ -368,7 +368,7 @@ export class WorkingMemory extends EventEmitter {
    */
   splice(start: number, deleteCount: number, ...items: InputMemory[]) {
     const newMemories = [...this.internalMemories]
-    newMemories.splice(start, deleteCount, ...this.clone(items).memories)
+    newMemories.splice(start, deleteCount, ...this.clone(items).internalMemories)
     return this.clone(newMemories)
   }
 
@@ -421,7 +421,7 @@ export class WorkingMemory extends EventEmitter {
     let startIndex = this.regionalIndex(regionName)
     if (startIndex === -1) {
       // if there is no region with that name, then it goes right before the first memory with no region
-      const firstMemoryWithoutRegion = this.memories.findIndex((memory) => {
+      const firstMemoryWithoutRegion = this.internalMemories.findIndex((memory) => {
         return !memory.region || memory.region === DEFAULT_REGION
       })
       startIndex = firstMemoryWithoutRegion === -1 ? this.length : firstMemoryWithoutRegion
@@ -432,8 +432,8 @@ export class WorkingMemory extends EventEmitter {
     const clone = this.clone(
       this.internalMemories
         .slice(0, startIndex)
-        .concat(memoriesWithRegion.memories)
-        .concat(withoutRegion.slice(startIndex).memories)
+        .concat(memoriesWithRegion.internalMemories)
+        .concat(withoutRegion.slice(startIndex).internalMemories)
     )
 
     if (this.regionOrder) {
@@ -503,14 +503,14 @@ export class WorkingMemory extends EventEmitter {
   }
 
   private regionalIndex(regionName: string) {
-    return this.memories.findIndex((memory) => {
-      return memory.region === regionName
+    return this.internalMemories.findIndex((memory) => {
+      return (memory.region || DEFAULT_REGION) === regionName
     })
   }
   
   private regionalMemories(regionName: string) {
     return this.internalMemories.filter((memory) => {
-      return memory.region === regionName
+      return (memory.region || DEFAULT_REGION) === regionName
     })
   }
 
@@ -560,7 +560,7 @@ export class WorkingMemory extends EventEmitter {
    */
   concat(other: MemoryListOrWorkingMemory) {
     const otherWorkingMemory = this.normalizeMemoryListOrWorkingMemory(other)
-    return this.clone(this.internalMemories.concat(otherWorkingMemory.memories))
+    return this.clone(this.internalMemories.concat(otherWorkingMemory.internalMemories))
   }
 
   /**
@@ -572,7 +572,7 @@ export class WorkingMemory extends EventEmitter {
    */
   prepend(otherWorkingMemory: MemoryListOrWorkingMemory) {
     const otherMemory = this.normalizeMemoryListOrWorkingMemory(otherWorkingMemory)
-    return this.clone(otherMemory.memories.concat(this.memories))
+    return this.clone(otherMemory.internalMemories.concat(this.internalMemories))
   }
 
   /**

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -409,7 +409,7 @@ export class WorkingMemory extends EventEmitter {
    */
   withRegion(regionName: string, ...memories: InputMemory[]) {
     if (regionName === DEFAULT_REGION) {
-      throw new Error('default is a reserved region name for memories without a region')
+      throw new Error('default is a reserved region name for memories without an explicit region')
     }
     const memoriesWithRegion = this.normalizeMemoryListOrWorkingMemory(memories.map((memory) => {
       return {


### PR DESCRIPTION
* adding a new memory with `{..., region: 'xxx'}` now does what you'd expect and adds it to the bottom of the region.
* error on trying to use 'default' region name in `withRegion` (but is allowed in `withMemory`)
* add `withRegionalOrder` which sets a persistent regional order for future `withRegion` calls
* `withRegion` now adds new regions right before the default region (to say another way, right after the last defined region)
* reduce object creation by switching some .memories to .internalMemories