### PR TITLE
add an override to clone to allow setting regionOrder in an ses environment

### DIFF
--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -480,7 +480,9 @@ export class WorkingMemory extends EventEmitter {
     constructor({ soulName, memories, postCloneTransformation, processor, regionOrder }: WorkingMemoryInitOptions);
     asyncMap(callback: (memory: Memory, i?: number) => Promise<InputMemory>): Promise<WorkingMemory>;
     at(index: number): Memory<Record<string, unknown>>;
-    clone(replacementMemories?: InputMemory[]): WorkingMemory;
+    clone(replacementMemories?: InputMemory[], overrides?: Partial<{
+        regionOrder: string[];
+    }>): WorkingMemory;
     concat(other: MemoryListOrWorkingMemory): WorkingMemory;
     // (undocumented)
     protected doTransform<SchemaType, PostProcessType>(transformation: MemoryTransformationOptions<SchemaType, PostProcessType>, opts: TransformOptions): Promise<(AsyncIterable<string> | this | Promise<unknown>)[] | (this | SchemaType | PostProcessType)[]>;

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -220,13 +220,15 @@ export class WorkingMemory extends EventEmitter {
    * const clonedMemory = originalMemory.clone([optionalNewMemories]);
    * ```
    */
-  clone(replacementMemories?: InputMemory[]) {
+  clone(replacementMemories?: InputMemory[], overrides: Partial<{ regionOrder: string[] }> = {}) {
+    const { regionOrder } = overrides
+
     const newMemory = new WorkingMemory({
       soulName: this.soulName,
       memories: replacementMemories || this.internalMemories,
       postCloneTransformation: this._postCloneTransformation,
       processor: this.processor,
-      regionOrder: this.regionOrder,
+      regionOrder: regionOrder || this.regionOrder,
     })
     return this._postCloneTransformation(newMemory)
   }
@@ -262,8 +264,7 @@ export class WorkingMemory extends EventEmitter {
    * ```
    */
   withRegionalOrder(...regionOrder: string[]) {
-    const clone = this.clone()
-    clone.regionOrder = regionOrder
+    const clone = this.clone(undefined, { regionOrder })
     return clone
   }
 


### PR DESCRIPTION
clone.regionOrder throws an error under the production hardened environment because it's a readonly property on a hardened WorkingMemory.

This extends clone to take regionOrder as an override.