### PR TITLE
default handling imrovements

### DIFF
--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -535,6 +535,7 @@ export class WorkingMemory extends EventEmitter {
     };
     withMemory(memory: InputMemory): WorkingMemory;
     withMonologue(content: string): WorkingMemory;
+    withOnlyRegions(...regionNames: string[]): WorkingMemory;
     withoutRegions(...regionNames: string[]): WorkingMemory;
     withRegion(regionName: string, ...memories: InputMemory[]): WorkingMemory;
     withRegionalOrder(...regionOrder: string[]): WorkingMemory;

--- a/packages/core/src/WorkingMemory.ts
+++ b/packages/core/src/WorkingMemory.ts
@@ -413,9 +413,6 @@ export class WorkingMemory extends EventEmitter {
    * ```
    */
   withRegion(regionName: string, ...memories: InputMemory[]) {
-    if (regionName === DEFAULT_REGION) {
-      throw new Error('default is a reserved region name for memories without an explicit region')
-    }
     const memoriesWithRegion = this.normalizeMemoryListOrWorkingMemory(memories.map((memory) => {
       return {
         ...memory,
@@ -504,6 +501,25 @@ export class WorkingMemory extends EventEmitter {
     return this.filter((memory) => {
       const region = memory.region || DEFAULT_REGION
       return !regionNames.includes(region)
+    })
+  }
+
+  /**
+   * Returns a new WorkingMemory instance that only includes memories from the specified region(s).
+   * 
+   * @param regionNames - The name of the region(s) to include in the working memory
+   * @returns A new WorkingMemory instance with only the memories from the specified regions.
+   * 
+   * @example
+   * ```
+   * const newWorkingMemory = workingMemory.withOnlyRegions("greetings");
+   * const newWorkingMemory = workingMemory.withOnlyRegions("system", "summary");
+   * ```
+   */
+  withOnlyRegions(...regionNames: string[]) {
+    return this.filter((memory) => {
+      const region = memory.region || DEFAULT_REGION
+      return regionNames.includes(region)
     })
   }
 

--- a/packages/core/tests/WorkingMemory.spec.ts
+++ b/packages/core/tests/WorkingMemory.spec.ts
@@ -193,11 +193,11 @@ describe("WorkingMemory", () => {
     expect(asyncMappedMemories.memories[1].content).to.equal("Async map test #2 async mapped")
   })
 
-  
+
   it("applies postCloneTransformations to transform WorkingMemory", () => {
     // This test is a trivial example to test functionality. The system is designed so library developers
     // can add their own hooks to working memory (for instance, prevent access to certain methods, or log usage, etc).
-    
+
     const postCloneTransformation = (wm: WorkingMemory) => {
       const transformedMemories = wm.memories.map(memory => ({
         ...memory,
@@ -303,7 +303,7 @@ describe("WorkingMemory", () => {
         .withMonologue("Memory #2")
 
       const memoriesWithRegion = memories.withRegion("system", fakeSystemMemeory)
-      
+
       const withReplacedRegion = memoriesWithRegion.withRegion("system", {
         role: ChatMessageRoleEnum.System,
         content: 'Replaced System',
@@ -354,29 +354,56 @@ describe("WorkingMemory", () => {
       expect(ordered.slice(-2).at(0)).to.have.property('region', 'system')
     })
 
-  it("removes regions from memory", () => {
-    const memories = new WorkingMemory({
-      soulName: "test",
-    }).withMonologue("Memory #1")
-      .withMonologue("Memory #2")
+    it("removes regions from memory", () => {
+      const memories = new WorkingMemory({
+        soulName: "test",
+      }).withMonologue("Memory #1")
+        .withMonologue("Memory #2")
 
-    const withSystem = memories.withRegion("system", {
-      role: ChatMessageRoleEnum.System,
-      content: 'System Memory',
+      const withSystem = memories.withRegion("system", {
+        role: ChatMessageRoleEnum.System,
+        content: 'System Memory',
+      })
+      const withSummary = withSystem.withRegion("summary", {
+        role: ChatMessageRoleEnum.System,
+        content: 'Summary Memory',
+      })
+
+      const withoutSystem = withSummary.withoutRegions('system')
+      expect(withoutSystem.length).to.equal(3)
+      expect(withoutSystem.at(0)).to.not.have.property('region', 'system')
+
+      const withoutSystemAndSummary = withoutSystem.withoutRegions('summary')
+      expect(withoutSystemAndSummary.length).to.equal(2)
+      expect(withoutSystemAndSummary.at(0)).to.not.have.property('region', 'summary')
     })
-    const withSummary = withSystem.withRegion("summary", {
-      role: ChatMessageRoleEnum.System,
-      content: 'Summary Memory',
+
+
+    it("returns a working memory with only specific regions", () => {
+      const memories = new WorkingMemory({
+        soulName: "test",
+      }).withMonologue("Memory #1")
+        .withMonologue("Memory #2")
+
+      const withSystem = memories.withRegion("system", {
+        role: ChatMessageRoleEnum.System,
+        content: 'System Memory',
+      })
+      
+      const withSummary = withSystem.withRegion("summary", {
+        role: ChatMessageRoleEnum.System,
+        content: 'Summary Memory',
+      })
+
+      const onlySystem = withSummary.withOnlyRegions('system')
+      expect(onlySystem.length).to.equal(1)
+      expect(onlySystem.at(0)).to.have.property('region', 'system')
+
+      const onlySystemAndSummary = withSummary.withOnlyRegions('system', 'summary')
+      expect(onlySystemAndSummary.length).to.equal(2)
+      expect(onlySystemAndSummary.at(0)).to.have.property('region', 'system')
+      expect(onlySystemAndSummary.at(1)).to.have.property('region', 'summary')
     })
-
-    const withoutSystem = withSummary.withoutRegions('system')
-    expect(withoutSystem.length).to.equal(3)
-    expect(withoutSystem.at(0)).to.not.have.property('region', 'system')
-
-    const withoutSystemAndSummary = withoutSystem.withoutRegions('summary')
-    expect(withoutSystemAndSummary.length).to.equal(2)
-    expect(withoutSystemAndSummary.at(0)).to.not.have.property('region', 'summary')
-  })
 
   })
 

--- a/packages/core/tests/WorkingMemory.spec.ts
+++ b/packages/core/tests/WorkingMemory.spec.ts
@@ -404,7 +404,6 @@ describe("WorkingMemory", () => {
       expect(onlySystemAndSummary.at(0)).to.have.property('region', 'system')
       expect(onlySystemAndSummary.at(1)).to.have.property('region', 'summary')
     })
-
   })
 
 })


### PR DESCRIPTION
* don't reserve word default, let people manipulate it
* add withOnlyRegions() to more easily get a section of the working memory.