### PR TITLE
bugs from using integrator

### DIFF
--- a/packages/engine/etc/engine.api.md
+++ b/packages/engine/etc/engine.api.md
@@ -58,7 +58,7 @@ export const defaultRagBucketName: (blueprint: string) => string;
 export type Embedding = number[];
 
 // @public (undocumented)
-export const load: (path: string) => Promise<string>;
+export const load: (path: string) => string;
 
 // @public (undocumented)
 export type MemoryIntegrator = <PropType>(params: MemoryIntegratorParameters) => Promise<MemoryIntegratorReturnTypes<PropType>> | MemoryIntegratorReturnTypes<PropType>;

--- a/packages/engine/src/load.ts
+++ b/packages/engine/src/load.ts
@@ -1,10 +1,12 @@
 import { fileURLToPath } from 'url';
 
-export const load = async (path: string) => {
+// The soul engine swaps out calls to load with an internal implementation
+// this is just for clarity locally.
+export const load = (path: string): string => {
   if (typeof process !== 'undefined' && process.versions != null && process.versions.node != null) {
     // We are in Node.js environment
-    const fs = await import('node:fs/promises');
-    const pathModule = await import('path');
+    const fs = require('node:fs');
+    const pathModule = require('path');
     let dirname;
     if (typeof __dirname === 'undefined') { // ES Modules
       dirname = pathModule.dirname(fileURLToPath(import.meta.url));
@@ -12,7 +14,7 @@ export const load = async (path: string) => {
       dirname = __dirname;
     }
     const fullPath = pathModule.join(dirname, path);
-    return fs.readFile(fullPath, 'utf-8');
+    return fs.readFileSync(fullPath, 'utf-8');
   } else {
     // We are in a browser environment
     console.error('load function is not supported in the browser');

--- a/packages/soul/etc/soul.api.md
+++ b/packages/soul/etc/soul.api.md
@@ -89,6 +89,8 @@ export class Soul extends EventEmitter<SoulEvents> {
     get store(): ReturnType<typeof syncedEventStore>;
 }
 
+export { SoulEvent }
+
 // @public (undocumented)
 export type SoulEvents = {
     [K in Actions]: (evt: ActionEvent) => void;

--- a/packages/soul/src/soul.ts
+++ b/packages/soul/src/soul.ts
@@ -10,13 +10,14 @@ import { getConnectedWebsocket } from "./sockets/soul-engine-socket.js";
 import { ContentStreamer } from "./content-streamer.js";
 import { syncedEventStore } from "./event-log.js";
 import { ToolHandler } from './tool-handler.js';
+
+export type { InteractionRequest, SoulEvent } from "@opensouls/core"
+
 // syntactic sugar for listening to actions which tend to be in the past tense
 // but allowing to listen to things like Action.SAYS
 export enum Actions {
   SAYS = "says",
 }
-
-export type { InteractionRequest } from "@opensouls/core"
 
 export enum Events {
   // this one is sent by the server


### PR DESCRIPTION
* reexport SoulEvent (need that when parsing events in react)
* switch load into a non-async function.