### PR TITLE
Fix Node dependency

### DIFF
--- a/packages/engine/src/load.ts
+++ b/packages/engine/src/load.ts
@@ -1,10 +1,10 @@
-import { fileURLToPath } from 'url';
-
 // The soul engine swaps out calls to load with an internal implementation
 // this is just for clarity locally.
 export const load = (path: string): string => {
   if (typeof window === "undefined" && typeof process !== 'undefined' && process.versions != null && process.versions.node != null) {
+
     // We are in Node.js environment
+    const { fileURLToPath } = require('url');
     const fs = require('node:fs');
     const pathModule = require('path');
     let dirname;

--- a/packages/engine/src/load.ts
+++ b/packages/engine/src/load.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 // The soul engine swaps out calls to load with an internal implementation
 // this is just for clarity locally.
 export const load = (path: string): string => {
-  if (typeof process !== 'undefined' && process.versions != null && process.versions.node != null) {
+  if (typeof window === "undefined" && typeof process !== 'undefined' && process.versions != null && process.versions.node != null) {
     // We are in Node.js environment
     const fs = require('node:fs');
     const pathModule = require('path');


### PR DESCRIPTION
Updated url to a dynamic import and added an extra `window === undefined` check

Caused by getting errors when building w/ Vite if url is imported

```
error during build:
node_modules/@opensouls/engine/dist/index.mjs (10:9): "fileURLToPath" is not exported by "__vite-browser-external", imported by "node_modules/@opensouls/engine/dist/index.mjs".

```